### PR TITLE
a few little things

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -13,3 +13,4 @@ EXPOSE 8888
 EXPOSE 4040
 
 ENV SPARK_HOME="/opt/conda/lib/python3.6/site-packages/pyspark"
+CMD [ "pyspark", "--driver-memory", "16g"]

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,10 @@
-#! /bin/bash
+#! /bin/sh
 set -e
 
 docker build -t movie_stats ./docker
-docker run --memory=4g -p 8889:8888 -p 4040:4040 -i --rm -v `pwd`/notebooks:/notebooks -t movie_stats bash -c 'pyspark --driver-memory 16g'
+
+docker run --rm \
+  --memory=4g \
+  -p 8889:8888 -p 4040:4040 \
+  -v "$(pwd)/notebooks:/notebooks" \
+  movie_stats


### PR DESCRIPTION
- it's 2018.  No one uses backticks anymore.
- moved command into docker file.
- made run.sh executable, and matched the shebang to what I think the intention was (based on the docs).